### PR TITLE
Add support for MC 1.21.1

### DIFF
--- a/dist/src/main/java/kr/toxicity/libraries/datacomponent/DataComponentAPIImpl.java
+++ b/dist/src/main/java/kr/toxicity/libraries/datacomponent/DataComponentAPIImpl.java
@@ -26,7 +26,7 @@ public final class DataComponentAPIImpl extends DataComponentAPI {
         this.current = current;
         if (current.equals(MinecraftVersionImpl.V1_20_5) || current.equals(MinecraftVersionImpl.V1_20_6)) {
             nms = new kr.toxicity.libraries.datacomponent.nms.v1_20_R4.NMSImpl();
-        } else if (current.equals(MinecraftVersionImpl.V1_21)) {
+        } else if (current.equals(MinecraftVersionImpl.V1_21) || current.equals(MinecraftVersionImpl.V1_21_1)) {
             nms = new kr.toxicity.libraries.datacomponent.nms.v1_21_R1.NMSImpl();
         }else {
             throw new UnsupportedOperationException("Unsupported minecraft version: " + current);

--- a/dist/src/main/java/kr/toxicity/libraries/datacomponent/MinecraftVersionImpl.java
+++ b/dist/src/main/java/kr/toxicity/libraries/datacomponent/MinecraftVersionImpl.java
@@ -14,6 +14,7 @@ record MinecraftVersionImpl(int first, int second, int third) implements Compara
         return COMPARATOR.compare(this, o);
     }
 
+    public static final MinecraftVersionImpl V1_21_1 = new MinecraftVersionImpl(1, 21, 1);
     public static final MinecraftVersionImpl V1_21 = new MinecraftVersionImpl(1, 21, 0);
     public static final MinecraftVersionImpl V1_20_6 = new MinecraftVersionImpl(1, 20, 6);
     public static final MinecraftVersionImpl V1_20_5 = new MinecraftVersionImpl(1, 20, 5);


### PR DESCRIPTION
This pull request adds support for MC 1.21.1. It's very easy because Spigot 1.21.1 also uses v1_21_R1