### PR TITLE
bug: 'lore' not 'item_lore'

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="temurin-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/nms/v1_20_R4/src/main/java/kr/toxicity/libraries/datacomponent/nms/v1_20_R4/CodecImpl.java
+++ b/nms/v1_20_R4/src/main/java/kr/toxicity/libraries/datacomponent/nms/v1_20_R4/CodecImpl.java
@@ -32,7 +32,7 @@ final class CodecImpl<T> implements kr.toxicity.libraries.datacomponent.api.Code
     private static final RegistryOps<JsonElement> OPS = RegistryAccess.fromRegistryOfRegistries(BuiltInRegistries.REGISTRY).createSerializationContext(JsonOps.INSTANCE);
 
     static final CodecImpl<Component> COMPONENT = of(ComponentSerialization.CODEC, t -> t.stream().count() == 1 && t.getStyle().isEmpty() && t.getContents() instanceof PlainTextContents textContents ? new JsonPrimitive(textContents.text()) : new JsonObject());
-    static final CodecImpl<ItemLore> ITEM_LORE = of(ItemLore.CODEC, t -> new JsonArray());
+    static final CodecImpl<ItemLore> LORE = of(ItemLore.CODEC, t -> new JsonArray());
     static final CodecImpl<Rarity> RARITY = of(Rarity.CODEC, t -> new JsonPrimitive(t.name().toLowerCase()));
     static final CodecImpl<Unit> UNIT = of(Codec.unit(Unit.INSTANCE), t -> new JsonPrimitive(true));
     static final CodecImpl<AdventureModePredicate> ADVENTURE_MODE_PREDICATE = of(AdventureModePredicate.CODEC, t -> new JsonObject());

--- a/nms/v1_20_R4/src/main/java/kr/toxicity/libraries/datacomponent/nms/v1_20_R4/Converters.java
+++ b/nms/v1_20_R4/src/main/java/kr/toxicity/libraries/datacomponent/nms/v1_20_R4/Converters.java
@@ -348,7 +348,7 @@ final class Converters {
             )
     );
 
-    static final Converter<ItemLore, net.minecraft.world.item.component.ItemLore> ITEM_LORE = Converter.of(
+    static final Converter<ItemLore, net.minecraft.world.item.component.ItemLore> LORE = Converter.of(
             l -> new net.minecraft.world.item.component.ItemLore(
                     l.lines().stream().map(COMPONENT::asVanilla).toList(),
                     l.styledLines().stream().map(COMPONENT::asVanilla).toList()

--- a/nms/v1_20_R4/src/main/java/kr/toxicity/libraries/datacomponent/nms/v1_20_R4/DataComponentTypeImpl.java
+++ b/nms/v1_20_R4/src/main/java/kr/toxicity/libraries/datacomponent/nms/v1_20_R4/DataComponentTypeImpl.java
@@ -74,11 +74,11 @@ final class DataComponentTypeImpl<T, R> implements kr.toxicity.libraries.datacom
             Converters.COMPONENT,
             CodecImpl.COMPONENT
     );
-    static final DataComponentTypeImpl<ItemLore, net.minecraft.world.item.component.ItemLore> ITEM_LORE = register(
-            "item_lore",
+    static final DataComponentTypeImpl<ItemLore, net.minecraft.world.item.component.ItemLore> LORE = register(
+            "lore",
             DataComponents.LORE,
-            Converters.ITEM_LORE,
-            CodecImpl.ITEM_LORE
+            Converters.LORE,
+            CodecImpl.LORE
     );
     static final DataComponentTypeImpl<Rarity, net.minecraft.world.item.Rarity> RARITY = register(
             "rarity",

--- a/nms/v1_20_R4/src/main/java/kr/toxicity/libraries/datacomponent/nms/v1_20_R4/NMSImpl.java
+++ b/nms/v1_20_R4/src/main/java/kr/toxicity/libraries/datacomponent/nms/v1_20_R4/NMSImpl.java
@@ -55,7 +55,7 @@ public final class NMSImpl implements NMS {
 
     @Override
     public @NotNull DataComponentType<ItemLore> lore() {
-        return DataComponentTypeImpl.ITEM_LORE;
+        return DataComponentTypeImpl.LORE;
     }
 
     @Override

--- a/nms/v1_21_R1/src/main/java/kr/toxicity/libraries/datacomponent/nms/v1_21_R1/CodecImpl.java
+++ b/nms/v1_21_R1/src/main/java/kr/toxicity/libraries/datacomponent/nms/v1_21_R1/CodecImpl.java
@@ -32,7 +32,7 @@ final class CodecImpl<T> implements kr.toxicity.libraries.datacomponent.api.Code
     private static final RegistryOps<JsonElement> OPS = RegistryAccess.fromRegistryOfRegistries(BuiltInRegistries.REGISTRY).createSerializationContext(JsonOps.INSTANCE);
 
     static final CodecImpl<Component> COMPONENT = of(ComponentSerialization.CODEC, t -> t.stream().count() == 1 && t.getStyle().isEmpty() && t.getContents() instanceof PlainTextContents textContents ? new JsonPrimitive(textContents.text()) : new JsonObject());
-    static final CodecImpl<ItemLore> ITEM_LORE = of(ItemLore.CODEC, t -> new JsonArray());
+    static final CodecImpl<ItemLore> LORE = of(ItemLore.CODEC, t -> new JsonArray());
     static final CodecImpl<Rarity> RARITY = of(Rarity.CODEC, t -> new JsonPrimitive(t.name().toLowerCase()));
     static final CodecImpl<Unit> UNIT = of(Codec.unit(Unit.INSTANCE), t -> new JsonPrimitive(true));
     static final CodecImpl<AdventureModePredicate> ADVENTURE_MODE_PREDICATE = of(AdventureModePredicate.CODEC, t -> new JsonObject());

--- a/nms/v1_21_R1/src/main/java/kr/toxicity/libraries/datacomponent/nms/v1_21_R1/Converters.java
+++ b/nms/v1_21_R1/src/main/java/kr/toxicity/libraries/datacomponent/nms/v1_21_R1/Converters.java
@@ -348,7 +348,7 @@ final class Converters {
             )
     );
 
-    static final Converter<ItemLore, net.minecraft.world.item.component.ItemLore> ITEM_LORE = Converter.of(
+    static final Converter<ItemLore, net.minecraft.world.item.component.ItemLore> LORE = Converter.of(
             l -> new net.minecraft.world.item.component.ItemLore(
                     l.lines().stream().map(COMPONENT::asVanilla).toList(),
                     l.styledLines().stream().map(COMPONENT::asVanilla).toList()

--- a/nms/v1_21_R1/src/main/java/kr/toxicity/libraries/datacomponent/nms/v1_21_R1/DataComponentTypeImpl.java
+++ b/nms/v1_21_R1/src/main/java/kr/toxicity/libraries/datacomponent/nms/v1_21_R1/DataComponentTypeImpl.java
@@ -74,11 +74,11 @@ final class DataComponentTypeImpl<T, R> implements kr.toxicity.libraries.datacom
             Converters.COMPONENT,
             CodecImpl.COMPONENT
     );
-    static final DataComponentTypeImpl<ItemLore, net.minecraft.world.item.component.ItemLore> ITEM_LORE = register(
-            "item_lore",
+    static final DataComponentTypeImpl<ItemLore, net.minecraft.world.item.component.ItemLore> LORE = register(
+            "lore",
             DataComponents.LORE,
-            Converters.ITEM_LORE,
-            CodecImpl.ITEM_LORE
+            Converters.LORE,
+            CodecImpl.LORE
     );
     static final DataComponentTypeImpl<Rarity, net.minecraft.world.item.Rarity> RARITY = register(
             "rarity",

--- a/nms/v1_21_R1/src/main/java/kr/toxicity/libraries/datacomponent/nms/v1_21_R1/NMSImpl.java
+++ b/nms/v1_21_R1/src/main/java/kr/toxicity/libraries/datacomponent/nms/v1_21_R1/NMSImpl.java
@@ -55,7 +55,7 @@ public final class NMSImpl implements NMS {
 
     @Override
     public @NotNull DataComponentType<ItemLore> lore() {
-        return DataComponentTypeImpl.ITEM_LORE;
+        return DataComponentTypeImpl.LORE;
     }
 
     @Override


### PR DESCRIPTION
In the source code, the id of DataComponentType.LORE is 'lore' not 'item_lore'
when i try to use id to get type i found this bug
```java
public static final DataComponentType<ItemLore> LORE = register(
        "lore", builder -> builder.persistent(ItemLore.CODEC).networkSynchronized(ItemLore.STREAM_CODEC).cacheEncoding()
    );
```